### PR TITLE
Add ability for mods to provide custom aiming reticals

### DIFF
--- a/schemas/config/gameplay.json
+++ b/schemas/config/gameplay.json
@@ -33,6 +33,22 @@
                     "type": "number",
                     "exclusiveMinimum": 0,
                     "description": "The default speed of how fast the shot spheres will be, in pixels per second."
+                },
+                "reticleSprite": {
+                    "type": "string",
+                    "description": "The aiming reticle sprite to use when Aiming Retical is on. Will fallback to the default drawn caret if not defined."
+                },
+                "reticleOffset": {
+                    "$ref": "../_structures/Vector2.json",
+                    "description": "The aiming reticle's offset, relative to the position the cursor is aiming at."
+                },
+                "reticleNextBallSprite": {
+                    "type": "string",
+                    "description": "The aiming reticle's next ball sprite to use when Aiming Retical is on. Will only be drawn if reticleSprite is defined."
+                },
+                "reticleNextBallOffset": {
+                    "$ref": "../_structures/Vector2.json",
+                    "description": "The aiming reticle's offset, relative to the top-left of the aiming retical."
                 }
             },
             "required": [

--- a/src/Shooter.lua
+++ b/src/Shooter.lua
@@ -274,13 +274,37 @@ function Shooter:draw()
 		local color = self:getReticalColor()
 		local sphereConfig = self:getSphereConfig()
 		if targetPos and self.color ~= 0 and sphereConfig.shootBehavior.type == "normal" then
-			love.graphics.setLineWidth(3 * _GetResolutionScale())
-			love.graphics.setColor(color.r, color.g, color.b)
-			local p1 = _PosOnScreen(targetPos + Vec2(-8, 8))
-			local p2 = _PosOnScreen(targetPos)
-			local p3 = _PosOnScreen(targetPos + Vec2(8, 8))
-			love.graphics.line(p1.x, p1.y, p2.x, p2.y)
-			love.graphics.line(p2.x, p2.y, p3.x, p3.y)
+            if self.config.reticleSprite then
+                local reticle = _Game.resourceManager:getSprite(self.config.reticleSprite)
+				local location = _PosOnScreen(targetPos)
+				local offset = _ParseVec2(self.config.reticleOffset or {x=0,y=0})
+				location.x = location.x + offset.x
+				location.y = location.y + offset.y
+                reticle:draw(location, Vec2(0.5, 0), nil, nil, nil, color)
+				if self.config.reticleNextBallSprite then
+                    local next = _Game.resourceManager:getSprite(self.config.reticleNextBallSprite)
+                    local nextColor = self:getNextReticalColor()
+                    -- Have the location be relative to the shooter, default to
+					-- it's top-left just like assigning shooter's nextBall
+					local nextBallOffset = _ParseVec2(self.config.reticleNextBallOffset or {x=0,y=0})
+                    local relativeLocation = location
+                    relativeLocation.x = location.x - (reticle.size.x / 2) + nextBallOffset.x
+					relativeLocation.y = location.y + nextBallOffset.y
+					next:draw(relativeLocation, Vec2(0,0), nil, nil, nil, nextColor)
+				end
+            else
+				love.graphics.setLineWidth(3 * _GetResolutionScale())
+				love.graphics.setColor(color.r, color.g, color.b)
+				local p1 = _PosOnScreen(targetPos + Vec2(-8, 8))
+				local p2 = _PosOnScreen(targetPos)
+				local p3 = _PosOnScreen(targetPos + Vec2(8, 8))
+				love.graphics.line(p1.x, p1.y, p2.x, p2.y)
+				love.graphics.line(p2.x, p2.y, p3.x, p3.y)
+			end
+
+			--_Game.resourceManager.
+
+			-- TODO: Add custom reticle support ~Shambles_SM
 
 			-- Fireball range highlight
 			if sphereConfig.hitBehavior.type == "fireball" or sphereConfig.hitBehavior.type == "colorCloud" then
@@ -367,6 +391,14 @@ function Shooter:getReticalColor()
 end
 
 
+function Shooter:getNextReticalColor()
+	local color = self:getNextSphereConfig().color
+	if type(color) == "string" then
+		return _Game.resourceManager:getColorPalette(color):getColor(_TotalTime * self:getSphereConfig().colorSpeed)
+	else
+		return color
+	end
+end
 
 function Shooter:spherePos()
 	return self.pos - Vec2(0, -5)

--- a/src/Shooter.lua
+++ b/src/Shooter.lua
@@ -275,22 +275,16 @@ function Shooter:draw()
 		local sphereConfig = self:getSphereConfig()
 		if targetPos and self.color ~= 0 and sphereConfig.shootBehavior.type == "normal" then
             if self.config.reticleSprite then
+				-- TODO: load sprite once
                 local reticle = _Game.resourceManager:getSprite(self.config.reticleSprite)
-				local location = _PosOnScreen(targetPos)
-				local offset = _ParseVec2(self.config.reticleOffset or {x=0,y=0})
-				location.x = location.x + offset.x
-				location.y = location.y + offset.y
+				local location = targetPos + (_ParseVec2(self.config.reticleOffset) or Vec2())
                 reticle:draw(location, Vec2(0.5, 0), nil, nil, nil, color)
 				if self.config.reticleNextBallSprite then
+					-- TODO: load sprite once
                     local next = _Game.resourceManager:getSprite(self.config.reticleNextBallSprite)
                     local nextColor = self:getNextReticalColor()
-                    -- Have the location be relative to the shooter, default to
-					-- it's top-left just like assigning shooter's nextBall
-					local nextBallOffset = _ParseVec2(self.config.reticleNextBallOffset or {x=0,y=0})
-                    local relativeLocation = location
-                    relativeLocation.x = location.x - (reticle.size.x / 2) + nextBallOffset.x
-					relativeLocation.y = location.y + nextBallOffset.y
-					next:draw(relativeLocation, Vec2(0,0), nil, nil, nil, nextColor)
+                    local nextLocation = location + (_ParseVec2(self.config.reticleNextBallOffset) or Vec2())
+					next:draw(nextLocation, Vec2(0.5, 0), nil, nil, nil, nextColor)
 				end
             else
 				love.graphics.setLineWidth(3 * _GetResolutionScale())


### PR DESCRIPTION
For now it only supports normal spheres. I would love to support radius spheres, but I do not have enough Math knowledge to do so.

This is a new addition to `config/gameplay.json`:
```json
    "shooter": {
        "...": "..."
        "reticleSprite": "sprites/game/reticle.json",
        "reticleOffset": { "x": 0, "y": 0 },
        "reticleNextBallSprite": "sprites/game/reticle_next_ball_s.json",
        "reticleNextBallOffset": { "x": 0, "y": 0 }
    },
```

`reticleSprite`: (string) The aiming reticle sprite to use when Aiming Retical is on. Will fallback to the default drawn caret if not defined.
`reticleOffset`: (Vec2) The aiming reticle's offset, relative to the position the cursor is aiming at.
`reticleNextBallSprite`: (string) The aiming reticle's next ball sprite to use when Aiming Retical is on. Will only be drawn if reticleSprite is defined.
`reticleNextBallOffset`: (Vec2) The aiming reticle's offset, relative to the top-left of the aiming retical.

Here's an example:
```json
    "reticleSprite": "sprites/game/reticle.json",
    "reticleOffset": { "x": 0, "y": 0 },
    "reticleNextBallSprite": "sprites/game/reticle_next_ball_s.json",
    "reticleNextBallOffset": { "x": 8, "y": 15 }
```
![Example of custom reticle](https://cdn.discordapp.com/attachments/735938974949966005/1027233772694933584/OpenSMCE_v0.46.0_-_Luxor_2022_10_05_22_47_57.png)