### PR TITLE
Implement Blend Modes

### DIFF
--- a/src/Configs/UI2Widget.lua
+++ b/src/Configs/UI2Widget.lua
@@ -41,6 +41,7 @@ function UI2WidgetConfig:new(data, path)
     else
         --error(string.format("Failed to load file %s, unknown Widget type: %s (expected \"rectangle\", \"sprite\", \"spriteButton\" or \"text\")", path, self.type))
     end
+    self.blendMode = data.blendMode
 end
 
 

--- a/src/Essentials/Font.lua
+++ b/src/Essentials/Font.lua
@@ -80,10 +80,17 @@ function Font:getTextSize(text)
 	end
 end
 
-function Font:draw(text, pos, align, color, alpha)
+function Font:draw(text, pos, align, color, alpha, blendMode)
 	align = align or Vec2(0.5)
 	color = color or Color()
-	alpha = alpha or 1
+    alpha = alpha or 1
+    blendMode = blendMode or "alpha"
+	-- see Sprite.lua on why this reassigment exists
+	if blendMode == "none" then
+		blendMode = "alpha"
+    end
+	---@diagnostic disable-next-line: param-type-mismatch
+    love.graphics.setBlendMode(blendMode)
 
 	if self.type == "image" then
 		love.graphics.setColor(color.r, color.g, color.b, alpha)

--- a/src/Essentials/Font.lua
+++ b/src/Essentials/Font.lua
@@ -80,7 +80,7 @@ function Font:getTextSize(text)
 	end
 end
 
-function Font:draw(text, pos, align, color, alpha, blendMode)
+function Font:draw(text, pos, align, color, alpha, scale, blendMode)
 	align = align or Vec2(0.5)
 	color = color or Color()
     alpha = alpha or 1
@@ -89,8 +89,16 @@ function Font:draw(text, pos, align, color, alpha, blendMode)
 	if blendMode == "none" then
 		blendMode = "alpha"
     end
+
+	local blendAlphaMode = "alphamultiply"
+    local modesToPremultiply = { "multiply", "lighten", "darken" }
+	for _,mode in pairs(modesToPremultiply) do
+		if mode == blendMode then
+			blendAlphaMode = "premultiplied"
+		end
+	end
 	---@diagnostic disable-next-line: param-type-mismatch
-    love.graphics.setBlendMode(blendMode)
+    love.graphics.setBlendMode(blendMode, blendAlphaMode)
 
 	if self.type == "image" then
 		love.graphics.setColor(color.r, color.g, color.b, alpha)

--- a/src/Essentials/Sprite.lua
+++ b/src/Essentials/Sprite.lua
@@ -87,17 +87,15 @@ function Sprite:draw(pos, align, state, frame, rot, color, alpha, scale, blendMo
 		love.graphics.setColor(unpack(color), alpha)
     end
 
-	--[[
 	local blendAlphaMode = "alphamultiply"
-    local modesToPremultiply = { "add", "subtract", "multiply", "lighten", "darken" }
+    local modesToPremultiply = { "multiply", "lighten", "darken" }
 	for _,mode in pairs(modesToPremultiply) do
 		if mode == blendMode then
 			blendAlphaMode = "premultiplied"
 		end
 	end
-	]]
 	---@diagnostic disable-next-line: param-type-mismatch
-    love.graphics.setBlendMode(blendMode)
+    love.graphics.setBlendMode(blendMode, blendAlphaMode)
 
 	self.img:draw(self:getFrame(state, frame), pos.x, pos.y, rot, scale.x * _GetResolutionScale(), scale.y * _GetResolutionScale())
 end

--- a/src/Essentials/Sprite.lua
+++ b/src/Essentials/Sprite.lua
@@ -65,20 +65,40 @@ end
 ---@param color Color? The sprite color.
 ---@param alpha number? Sprite transparency. `0` is fully transparent. `1` is fully opaque.
 ---@param scale Vector2? The scale of this sprite.
-function Sprite:draw(pos, align, state, frame, rot, color, alpha, scale)
+---@param blendMode "none"|"alpha"|"screen"|"add"|"subtract"|"multiply"|"lighten"|"darken"? The blending mode to use.
+function Sprite:draw(pos, align, state, frame, rot, color, alpha, scale, blendMode)
 	align = align or Vec2()
 	state = state or 1
 	frame = frame or Vec2(1)
 	rot = rot or 0
 	color = color or Color()
 	alpha = alpha or 1
-	scale = scale or Vec2(1)
+    scale = scale or Vec2(1)
+    blendMode = blendMode or "alpha"
+    -- this is for convenience reasons so json files can use "none"
+	-- instead of "alpha", but the option is there regardless
+	if blendMode == "none" then
+		blendMode = "alpha"
+    end
 	pos = _PosOnScreen(pos - (align * scale * self.frameSize):rotate(rot))
 	if color.r then -- temporary chunk
 		love.graphics.setColor(color.r, color.g, color.b, alpha)
 	else
 		love.graphics.setColor(unpack(color), alpha)
+    end
+
+	--[[
+	local blendAlphaMode = "alphamultiply"
+    local modesToPremultiply = { "add", "subtract", "multiply", "lighten", "darken" }
+	for _,mode in pairs(modesToPremultiply) do
+		if mode == blendMode then
+			blendAlphaMode = "premultiplied"
+		end
 	end
+	]]
+	---@diagnostic disable-next-line: param-type-mismatch
+    love.graphics.setBlendMode(blendMode)
+
 	self.img:draw(self:getFrame(state, frame), pos.x, pos.y, rot, scale.x * _GetResolutionScale(), scale.y * _GetResolutionScale())
 end
 

--- a/src/Particle/Piece.lua
+++ b/src/Particle/Piece.lua
@@ -55,7 +55,8 @@ function ParticlePiece:new(manager, spawner, data)
 	self.lifetime = self.lifespan
 	self.time = 0
 
-	self.sprite = _Game.resourceManager:getSprite(data.sprite)
+    self.sprite = _Game.resourceManager:getSprite(data.sprite)
+	self.blendMode = data.blendMode
 	self.animationSpeed = data.animationSpeed
 	self.animationFrameCount = data.animationFrameCount
 	self.animationLoop = data.animationLoop
@@ -165,7 +166,7 @@ end
 
 function ParticlePiece:draw(layer)
 	if self.layer == layer then
-		self.sprite:draw(self:getPos(), Vec2(0.5), nil, Vec2(math.min(math.floor(self.animationFrame), self.animationFrameCount), 1), nil, self:getColor(), self:getAlpha())
+		self.sprite:draw(self:getPos(), Vec2(0.5), nil, Vec2(math.min(math.floor(self.animationFrame), self.animationFrameCount), 1), nil, self:getColor(), self:getAlpha(), nil, self.blendMode)
 	end
 end
 

--- a/src/UI/Widget.lua
+++ b/src/UI/Widget.lua
@@ -72,6 +72,7 @@ function UIWidget:new(name, data, parent)
 			self.children[childN] = UIWidget(childN, child, self)
 		end
 	end
+	self.blendMode = data.blendMode
 
 	self.inheritShow = data.inheritShow
 	self.inheritHide = data.inheritHide

--- a/src/UI/WidgetSprite.lua
+++ b/src/UI/WidgetSprite.lua
@@ -17,7 +17,7 @@ end
 
 
 function UIWidgetSprite:draw()
-	self.sprite:draw(self.parent:getPos(), nil, nil, nil, nil, nil, self.parent:getAlpha())
+	self.sprite:draw(self.parent:getPos(), nil, nil, nil, nil, nil, self.parent:getAlpha(), nil, self.parent.blendMode)
 end
 
 return UIWidgetSprite

--- a/src/UI/WidgetSpriteButton.lua
+++ b/src/UI/WidgetSpriteButton.lua
@@ -64,7 +64,7 @@ function UIWidgetSpriteButton:draw()
 		end
 	end
 
-	self.sprite:draw(pos, nil, self:getState(), nil, nil, nil, alpha)
+	self.sprite:draw(pos, nil, self:getState(), nil, nil, nil, alpha, nil, self.parent.blendMode)
 end
 
 function UIWidgetSpriteButton:getState()

--- a/src/UI/WidgetSpriteProgress.lua
+++ b/src/UI/WidgetSpriteProgress.lua
@@ -39,7 +39,7 @@ function UIWidgetSpriteProgress:draw(variables)
 	local pos = self.parent:getPos()
 	local pos2 = _PosOnScreen(pos)
 	love.graphics.setScissor(pos2.x, pos2.y, self.size.x * _GetResolutionScale() * self.value, self.size.y * _GetResolutionScale())
-	self.sprite:draw(pos, nil, nil, nil, nil, nil, self.parent:getAlpha())
+	self.sprite:draw(pos, nil, nil, nil, nil, nil, self.parent:getAlpha(), nil, self.parent.blendMode)
 	love.graphics.setScissor()
 end
 

--- a/src/UI/WidgetText.lua
+++ b/src/UI/WidgetText.lua
@@ -22,7 +22,7 @@ end
 
 
 function UIWidgetText:draw(variables)
-	self.font:draw(self.textTmp, self.parent:getPos(), self.align, nil, self.parent:getAlpha())
+	self.font:draw(self.textTmp, self.parent:getPos(), self.align, nil, self.parent:getAlpha(), nil, self.parent.blendMode)
 end
 
 function UIWidgetText:getSize()

--- a/src/UI/WidgetTextInput.lua
+++ b/src/UI/WidgetTextInput.lua
@@ -45,11 +45,11 @@ end
 function UIWidgetTextInput:draw(variables)
 	local pos = self.parent:getPos()
 	local alpha = self.parent:getAlpha()
-	self.font:draw(self.text, pos, self.align, nil, alpha)
+	self.font:draw(self.text, pos, self.align, nil, alpha, nil, self.parent.blendMode)
 	if self.cursorSprite then
 		local cpos = pos + Vec2(self:getSize().x * (1 - self.align.x), 0)
 		local frame = math.floor(self.cursorSpriteBlink * 2) + 1
-		self.cursorSprite:draw(cpos, nil, nil, Vec2(frame, 1), nil, nil, alpha)
+		self.cursorSprite:draw(cpos, nil, nil, Vec2(frame, 1), nil, nil, alpha, nil, self.parent.blendMode)
 	end
 end
 

--- a/src/UI2/Node.lua
+++ b/src/UI2/Node.lua
@@ -51,14 +51,17 @@ function UI2Node:new(manager, config, name, parent)
     -- Widget
     local w = config.widget
     if w then
+        if not w.blendMode then
+            w.blendMode = "alpha"
+        end
         if w.type == "rectangle" then
-            self.widget = UI2WidgetRectangle(self, w.align, w.size, w.color)
+            self.widget = UI2WidgetRectangle(self, w.align, w.blendMode, w.size, w.color)
         elseif w.type == "sprite" then
-            self.widget = UI2WidgetSprite(self, w.align, w.sprite)
+            self.widget = UI2WidgetSprite(self, w.align, w.sprite, w.blendMode)
         elseif w.type == "spriteButton" then
-            self.widget = UI2WidgetSpriteButton(self, w.align, w.sprite, w.shape, w.callbacks)
+            self.widget = UI2WidgetSpriteButton(self, w.align, w.sprite,w.blendMode,  w.shape, w.callbacks)
         elseif w.type == "text" then
-            self.widget = UI2WidgetText(self, w.align, w.font, w.text, w.color)
+            self.widget = UI2WidgetText(self, w.align, w.font, w.blendMode,  w.text, w.color)
         end
     end
 end

--- a/src/UI2/WidgetRectangle.lua
+++ b/src/UI2/WidgetRectangle.lua
@@ -9,14 +9,16 @@ local UI2WidgetRectangle = class:derive("UI2WidgetRectangle")
 ---Constructs a new Rectangle Widget.
 ---@param node UI2Node The Node this Widget is bound to.
 ---@param align Vector2 The Widget's alignment.
+---@param blendMode string The blend mode to be used for this Text.
 ---@param size Vector2 This Rectangle's size.
 ---@param color Color This Rectangle's color.
-function UI2WidgetRectangle:new(node, align, size, color)
+function UI2WidgetRectangle:new(node, align, blendMode, size, color)
 	self.type = "rectangle"
 
 	self.node = node
 	self.align = align
 
+	self.blendMode = blendMode
 	self.size = size
 	self.color = color
 end
@@ -39,6 +41,7 @@ end
 
 ---Draws this Widget on the screen.
 function UI2WidgetRectangle:draw()
+	love.graphics.setBlendMode(self.blendMode)
 	love.graphics.setColor(self.color.r, self.color.g, self.color.b, self.node:getGlobalAlpha())
 	local pos = _PosOnScreen(self:getPos())
 	local size = self:getSize() * _GetResolutionScale()

--- a/src/UI2/WidgetSprite.lua
+++ b/src/UI2/WidgetSprite.lua
@@ -10,13 +10,15 @@ local UI2WidgetSprite = class:derive("UI2WidgetSprite")
 ---@param node UI2Node The Node this Widget is bound to.
 ---@param align Vector2 The Widget's alignment.
 ---@param sprite Sprite The Sprite to be drawn as this Widget.
-function UI2WidgetSprite:new(node, align, sprite)
+---@param blendMode string The blend mode to be used for this Text.
+function UI2WidgetSprite:new(node, align, sprite, blendMode)
 	self.type = "sprite"
 
 	self.node = node
 	self.align = align
 
-	self.sprite = sprite
+    self.sprite = sprite
+	self.blendMode = blendMode
 end
 
 
@@ -37,7 +39,7 @@ end
 
 ---Draws this Widget on the screen.
 function UI2WidgetSprite:draw()
-	self.sprite:draw(self:getPos(), nil, nil, nil, nil, nil, self.node:getGlobalAlpha(), self.node:getGlobalScale())
+	self.sprite:draw(self:getPos(), nil, nil, nil, nil, nil, self.node:getGlobalAlpha(), self.node:getGlobalScale(), self.blendMode)
 end
 
 

--- a/src/UI2/WidgetSpriteButton.lua
+++ b/src/UI2/WidgetSpriteButton.lua
@@ -12,15 +12,17 @@ local Vec2 = require("src/Essentials/Vector2")
 ---@param node UI2Node The Node this Widget is bound to.
 ---@param align Vector2 The Widget's alignment.
 ---@param sprite Sprite The Sprite to be drawn as this Widget.
+---@param blendMode string The blend mode to be used for this Text.
 ---@param shape string Can be `"rectangle"` or `"ellipse"`. Defines the button hitbox.
 ---@param callbacks table A table of callbacks which should be fired on certain events.
-function UI2WidgetSpriteButton:new(node, align, sprite, shape, callbacks)
+function UI2WidgetSpriteButton:new(node, align, sprite, blendMode, shape, callbacks)
 	self.type = "spriteButton"
 
     self.node = node
 	self.align = align
 
 	self.sprite = sprite
+	self.blendMode = blendMode
 	self.shape = shape
 	self.callbacks = callbacks
 
@@ -117,7 +119,7 @@ end
 
 ---Draws this Widget.
 function UI2WidgetSpriteButton:draw()
-	self.sprite:draw(self:getPos(), nil, self:getState(), nil, nil, nil, self.node:getGlobalAlpha(), self.node:getGlobalScale())
+	self.sprite:draw(self:getPos(), nil, self:getState(), nil, nil, nil, self.node:getGlobalAlpha(), self.node:getGlobalScale(), self.blendMode)
 end
 
 

--- a/src/UI2/WidgetText.lua
+++ b/src/UI2/WidgetText.lua
@@ -10,17 +10,19 @@ local UI2WidgetText = class:derive("UI2WidgetText")
 ---@param node UI2Node The Node this Widget is bound to.
 ---@param align Vector2 The Widget's alignment.
 ---@param font Font The Font to be used for this Text.
+---@param blendMode string The blend mode to be used for this Text.
 ---@param text string The text to be written in this Widget.
 ---@param color Color The Color to be used for the Font.
-function UI2WidgetText:new(node, align, font, text, color)
+function UI2WidgetText:new(node, align, font, blendMode, text, color)
 	self.type = "text"
 
 	self.node = node
 	self.align = align
 
 	self.font = font
+	self.blendMode = blendMode
 	self.text = text
-	self.color = color
+    self.color = color
 end
 
 
@@ -41,7 +43,7 @@ end
 
 ---Draws this Widget on the screen.
 function UI2WidgetText:draw()
-	self.font:draw(self.text, self.node:getGlobalPos(), self.align, self.color, self.node:getGlobalAlpha(), self.node:getGlobalScale())
+	self.font:draw(self.text, self.node:getGlobalPos(), self.align, self.color, self.node:getGlobalAlpha(), self.node:getGlobalScale(), self.blendMode)
 end
 
 

--- a/src/mathmethods.lua
+++ b/src/mathmethods.lua
@@ -22,3 +22,15 @@ function _MathWeightedRandom(weights)
 	end
 	return i
 end
+
+
+
+function _MathAreKeysInTable(tbl, ...)
+    for _, v in pairs({ ... }) do
+        tbl = tbl[v]
+        if type(tbl) ~= "table" then
+            return tbl
+        end
+    end
+    return tbl
+end


### PR DESCRIPTION
The blending modes available are the same as what LOVE2D as of 11.3 offers:
- `alpha` - Default. This also takes place if `none` is used.
- `replace` - Essentially renders the sprite without an alpha.
- `screen` - Screen blending
- `add` - Additive blending
- `subtract` - Subtractive blending
- `multiply` - Multiplicative blending (which is better used for darkening objects).
- `lighten` / `darken` - `math.min`/`math.max` blending.

(The second commit isn't related but it was also on the ZB remake repository so whatever)